### PR TITLE
Re-use underlying message server for same-chain transfer

### DIFF
--- a/x/bech32ics20/keeper/msg_server.go
+++ b/x/bech32ics20/keeper/msg_server.go
@@ -87,36 +87,6 @@ func (k msgServer) Send(goCtx context.Context, msg *banktypes.MsgSend) (*banktyp
 }
 
 func (k msgServer) MultiSend(goCtx context.Context, msg *banktypes.MsgMultiSend) (*banktypes.MsgMultiSendResponse, error) {
-	ctx := sdk.UnwrapSDKContext(goCtx)
-
-	// NOTE: totalIn == totalOut should already have been checked
-	for _, in := range msg.Inputs {
-		if err := k.SendEnabledCoins(ctx, in.Coins...); err != nil {
-			return nil, err
-		}
-	}
-
-	for _, out := range msg.Outputs {
-		accAddr, err := sdk.AccAddressFromBech32(out.Address)
-		if err != nil {
-			panic(err)
-		}
-		if k.BlockedAddr(accAddr) {
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "%s is not allowed to receive transactions", out.Address)
-		}
-	}
-
-	err := k.InputOutputCoins(ctx, msg.Inputs, msg.Outputs)
-	if err != nil {
-		return nil, err
-	}
-
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, banktypes.AttributeValueCategory),
-		),
-	)
-
-	return &banktypes.MsgMultiSendResponse{}, nil
+	bankMsgServer := bankkeeper.NewMsgServerImpl(k.Keeper.Keeper)
+	return bankMsgServer.MultiSend(goCtx, msg)
 }


### PR DESCRIPTION
Should simplify the logic / make this more compatible across SDK versions